### PR TITLE
Adding cluster name to cdk config

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -26,7 +26,7 @@ class BaseVPCStack(core.Stack):
         self.ecs_cluster = aws_ecs.Cluster(
             self, "ECSCluster",
             vpc=self.vpc,
-            cluster_name='container-demo'
+            cluster_name="container-demo"
         )
 
         # Adding service discovery namespace to cluster

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -25,7 +25,8 @@ class BaseVPCStack(core.Stack):
         # Creating ECS Cluster in the VPC created above
         self.ecs_cluster = aws_ecs.Cluster(
             self, "ECSCluster",
-            vpc=self.vpc
+            vpc=self.vpc,
+            cluster_name='container-demo'
         )
 
         # Adding service discovery namespace to cluster


### PR DESCRIPTION
This will ensure that container insights section of ecsworkshop can grab the arn of the ecs cluster based on name